### PR TITLE
Strip leading dot from linkname in hardlink to symlink translation

### DIFF
--- a/install.py
+++ b/install.py
@@ -272,8 +272,10 @@ else:
 						if not os.path.exists(dirname):
 							os.makedirs(dirname, exist_ok=True)
 
+						# if a hardlink's linkname begins with a leading dot, the dot must be omitted,
+						# or else the symlink will be broken because it will be interpreted as relative
 						with open(file.name, 'w', encoding='utf-8') as link:
-							link.write(file.linkname)
+							link.write(file.linkname.lstrip('.') if file.islnk() else file.linkname)
 
 					elif file.isdev():
 


### PR DESCRIPTION
This solves a problem that I have observed with images containing
git, where /usr/bin/git is a hardlink having a linkname value of
'./usr/bin/git-upload-archive', which translates to a broken
symlink if the leading dot is not omitted.