### PR TITLE
Fix installing archives with full path

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -157,7 +157,7 @@ def parse_image_arg(argv, can_be_file = False):
 			if idx != -1:
 				break
 
-		label = argvl[:idx]
+		label = os.path.basename(argvl[:idx])
 
 		if label.startswith('rootfs_'):
 			label = label[len('rootfs_'):]


### PR DESCRIPTION
Running

     install.py t:\mydebian.tar.gz

breaks the installation process because the resulting switch label is the full path specified on the command line (including the : from the drive specification). This only takes the filename to name the resulting distribution.