### PR TITLE
Check if the temp folder exists and is non empty to determine if LXSS…

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -194,7 +194,7 @@ def probe_wsl(silent = False):
 		print('%s[!]%s The Linux subsystem is not installed. Please go through the standard installation procedure first.' % (Fore.RED, Fore.RESET))
 		sys.exit(-1)
 
-	if os.path.exists(os.path.join(basedir, 'temp')):
+	if os.path.exists(os.path.join(basedir, 'temp')) and os.listdir(os.path.join(basedir, 'temp')):
 		if silent:
 			return None, None
 


### PR DESCRIPTION
… is running.

Addresses #65.

Simply checking for the existence of the folder isn't enough to determine if a LXSS is running,
as the folder can exist while a no LXSSes are running. Checking for nonempty fixes this condition.